### PR TITLE
Grant WP privileges in MariaDB init.sql

### DIFF
--- a/docker/mariadb/init/init.sql
+++ b/docker/mariadb/init/init.sql
@@ -1,4 +1,8 @@
 CREATE DATABASE wordpress_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 CREATE USER 'wp_user'@'%' IDENTIFIED BY 'motdepasse_securise';
-GRANT SELECT, INSERT, UPDATE, EXECUTE ON wordpress_db.* TO 'wp_user'@'%';
+# Grant only the privileges required by WordPress for managing its tables
+GRANT SELECT, INSERT, UPDATE, DELETE,
+      CREATE, DROP, ALTER, INDEX,
+      CREATE TEMPORARY TABLES
+  ON wordpress_db.* TO 'wp_user'@'%';
 FLUSH PRIVILEGES;


### PR DESCRIPTION
## Summary
- update MariaDB initialization script so the `wp_user` has all privileges required for installing and managing WordPress tables

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68631289a880832598a5bf2523a2ed9d